### PR TITLE
Fixing pathlib stem errors and s3_root misconfiguration

### DIFF
--- a/tesp/workflow.py
+++ b/tesp/workflow.py
@@ -210,15 +210,17 @@ class Package_S3(luigi.Task):
     }
 
     def requires(self):
-        return Package(self.level1, self.workdir, self.granule, self.pkgdir)
+        s3_root = "http://{}.s3-{}.amazonaws.com/{}".format(
+            self.s3_bucket, self.s3_bucket_region, self.s3_key_prefix)
+        return Package(self.level1, self.workdir, self.granule, self.pkgdir, s3_root=s3_root)
 
     def output(self):
         # Assumes that the flag file is at the root of the package
         resolved_checksum = Path(self.input().path).resolve()
         return S3FlagTarget(
             's3://{}/{}/'.format(self.s3_bucket, self.s3_key_prefix) + \
-            resolved_checksum.parent.stem + '/',
-            flag=resolved_checksum.stem + resolved_checksum.suffix
+            resolved_checksum.parent.name + '/',
+            flag=resolved_checksum.name
         )
 
     def run(self):


### PR DESCRIPTION
Fixing errors in my initial commit:
* Including s3_root configuration in Package_S3
* calling '.stem' causes part of the file name to be dropped if a period appears in the name, the proper api call is .name