### PR TITLE
Datacube handles relative paths; S3 ARD is not required in packaging

### DIFF
--- a/tesp/package.py
+++ b/tesp/package.py
@@ -412,7 +412,7 @@ def create_checksum(outdir):
 
 
 def package(l1_path, wagl_fname, fmask_fname, yamls_path, outdir,
-            url_root, granule=None, acq_parser_hint=None):
+            granule=None, acq_parser_hint=None):
     """
     Package an L2 product.
 
@@ -435,10 +435,6 @@ def package(l1_path, wagl_fname, fmask_fname, yamls_path, outdir,
     :param outdir:
         A string containing the full file pathname to the directory
         that will contain the packaged Level-2 datasets.
-
-    :param url_root:
-        A string containing the url root path of a http address such as
-        an Amazon S3 or Google Cloud Storage bucket.
 
     :param acq_parser_hint:
         A string that hints at which acquisition parser should be used.
@@ -507,17 +503,6 @@ def package(l1_path, wagl_fname, fmask_fname, yamls_path, outdir,
         tags = merge_metadata(l1_tags, wagl_tags, granule, img_paths)
 
         with open(pjoin(out_path, 'ARD-METADATA.yaml'), 'w') as src:
-            yaml.dump(tags, src, default_flow_style=False, indent=4)
-
-        # update to url/http paths
-        url_paths = img_paths.copy()
-        for key in url_paths:
-            url_paths[key]['path'] = ppjoin(url_root, url_paths[key]['path'])
-
-        # create http paths for s3 yaml doc
-        tags['image']['bands'] = url_paths
-
-        with open(pjoin(out_path, 'ARD-METADATA-S3.yaml'), 'w') as src:
             yaml.dump(tags, src, default_flow_style=False, indent=4)
 
         # finally the checksum

--- a/tesp/workflow.py
+++ b/tesp/workflow.py
@@ -133,7 +133,6 @@ class Package(luigi.Task):
     workdir = luigi.Parameter()
     granule = luigi.Parameter(default=None)
     pkgdir = luigi.Parameter()
-    url_root = luigi.Parameter()
     yamls_dir = luigi.Parameter()
     cleanup = luigi.BoolParameter()
     acq_parser_hint = luigi.Parameter(default=None)
@@ -156,7 +155,7 @@ class Package(luigi.Task):
     def run(self):
         inputs = self.input()
         package(self.level1, inputs['wagl'].path, inputs['fmask'].path,
-                self.yamls_dir, self.pkgdir, self.url_root, self.granule,
+                self.yamls_dir, self.pkgdir, self.granule,
                 self.acq_parser_hint)
 
         if self.cleanup:
@@ -173,7 +172,6 @@ class ARDP(luigi.WrapperTask):
     level1_list = luigi.Parameter()
     workdir = luigi.Parameter()
     pkgdir = luigi.Parameter()
-    url_root = luigi.Parameter()
     acq_parser_hint = luigi.Parameter(default=None)
 
     def requires(self):
@@ -188,8 +186,7 @@ class ARDP(luigi.WrapperTask):
                 acq = container.get_acquisitions(None, granule, False)[0]
                 ymd = acq.acquisition_datetime.strftime('%Y-%m-%d')
                 pkgdir = pjoin(self.pkgdir, ymd)
-                url_root = pjoin(self.url_root, ymd)
-                yield Package(level1, work_dir, granule, pkgdir, url_root)
+                yield Package(level1, work_dir, granule, pkgdir)
 
 
 @inherits(Package)
@@ -198,13 +195,11 @@ class PackageS3(luigi.Task):
     """
     Uploads the packaged data to an s3_bucket and prefix after running the
     Package task successfully.
-    s3_bucket and s3_prefix_key are used for the destination path,
-    s3_bucket_region is used to resolve s3_root for the S3-ARD.yml
+    s3_bucket and s3_key_prefix are used for the destination path,
     """
 
     s3_bucket = luigi.Parameter()
     s3_key_prefix = luigi.Parameter()
-    s3_bucket_region = luigi.Parameter()
     s3_object_base_tags = luigi.DictParameter(default={},
                                               significant=False)
     s3_client_args = luigi.DictParameter(default={},
@@ -259,10 +254,7 @@ class PackageS3(luigi.Task):
 
 
     def requires(self):
-        url_root = "http://{}.s3-{}.amazonaws.com/{}".format(
-            self.s3_bucket, self.s3_bucket_region, self.s3_key_prefix)
-        return Package(self.level1, self.workdir, self.granule, self.pkgdir,
-                       url_root)
+        return Package(self.level1, self.workdir, self.granule, self.pkgdir)
 
     def output(self):
         # Assumes that the flag file is at the root of the package
@@ -334,7 +326,6 @@ class ARDPS3(luigi.WrapperTask):
 
     s3_bucket = luigi.Parameter()
     s3_key_prefix = luigi.Parameter()
-    s3_bucket_region = luigi.Parameter()
 
     def requires(self):
         with open(self.level1_list) as src:
@@ -350,8 +341,7 @@ class ARDPS3(luigi.WrapperTask):
                 pkgdir = pjoin(self.pkgdir, ymd)
                 yield PackageS3(
                     level1, work_dir, granule, pkgdir, s3_bucket=self.s3_bucket,
-                    s3_key_prefix=ppjoin(self.s3_key_prefix, ymd),
-                    s3_bucket_region=self.s3_bucket_region
+                    s3_key_prefix=ppjoin(self.s3_key_prefix, ymd)
                 )
 
 


### PR DESCRIPTION
Removes  S3-ARD generation from tesp

- [x] Confirm test run