### PR TITLE
Fixes to level-1 md generation; s3 contrib install and ARD file naming

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@
 
 from setuptools import setup, find_packages
 
+# There is a bug in the 2.7.6 release of luigi in the luigi.contrib.s3 module
+# Using an unreleased version until it is packaged and released
+
+
 setup(name='tesp',
       version='0.0.5',
       description=('A temporary solution to get packaging underway. '
@@ -27,7 +31,8 @@ setup(name='tesp',
       ],
       dependency_links=[
           'git+https://github.com/GeoscienceAustralia/eo-datasets@develop#egg=eodatasets-0.1dev',
-          'git+https://github.com/OpenDataCubePipelines/eugl.git#egg=eugl-0.0.2'
+          'git+https://github.com/OpenDataCubePipelines/eugl.git#egg=eugl-0.0.2',
+          'git+https://github.com/spotify/luigi.git@f9a99dce22e2887406c6d156d5d669660547d257#egg=luigi-2.7.7'
       ],
       scripts=['bin/s2package', 'bin/ard_pbs', 'bin/search_s2'],
       include_package_data=True)

--- a/tesp/ga_metadata/ls_usgs_l1_prepare.py
+++ b/tesp/ga_metadata/ls_usgs_l1_prepare.py
@@ -127,7 +127,7 @@ def get_mtl_content(acquisition_path):
     from Earth Explorer or GloVis
     """
 
-    if tarfile.is_tarfile(acquisition_path):
+    if os.path.isfile(str(acquisition_path)) and tarfile.is_tarfile(str(acquisition_path)):
         with tarfile.open(str(acquisition_path), 'r') as tp:
             try:
                 internal_file = next(filter(lambda memb: 'MTL' in memb.name, tp.getmembers()))
@@ -139,7 +139,7 @@ def get_mtl_content(acquisition_path):
                     "MTL file not found in {}".format(str(acquisition_path))
                 )
     else:
-        path = find_in(acquisition_path, 'MTL')
+        path = find_in(str(acquisition_path), 'MTL')
         filename = Path(path).stem
         with path.open('r') as fp:
             mtl_tree = _parse_group(fp)['L1_METADATA_FILE']

--- a/tesp/package.py
+++ b/tesp/package.py
@@ -53,7 +53,7 @@ LEVELS = [2, 4, 8, 16, 32]
 PATTERN1 = re.compile(
     r'(?P<prefix>(?:.*_)?)(?P<band_name>B[0-9][A0-9]|B[0-9]*|B[0-9a-zA-z]*)'
     r'(?P<extension>\.TIF)')
-PATTERN2 = re.compile('(L1[GTPC]{1,2})')
+PATTERN2 = re.compile('(L1[GTPCS]{1,2})')
 ARD = 'ARD'
 QA = 'QA'
 SUPPS = 'SUPPLEMENTARY'


### PR DESCRIPTION
* Fixes to MD generation access paths
* Update to account for the product type name change (from G -> GS)
* Fix on the referenced luigi version to circumvent an issue in their s3 contrib module