### PR TITLE
Add umask option to pbs submission for group readable files

### DIFF
--- a/bin/ard_pbs
+++ b/bin/ard_pbs
@@ -17,6 +17,7 @@ from wagl.tiling import scatter
 
 PBS_RESOURCES = ("""#!/bin/bash
 #PBS -P {project}
+#PBS -W umask=017
 #PBS -q {queue}
 #PBS -l walltime={walltime},mem={memory}GB,ncpus={ncpus},jobfs={jobfs}GB,other=pernodejobfs
 #PBS -l wd


### PR DESCRIPTION
* Changes the default umask for jobs submitted through ard_pbs, this also applies to the log files (job.e*, job.o* logs generated by the submission).